### PR TITLE
Give more informative error message when avformat_open_input fails

### DIFF
--- a/src/Media/MediaSourceElement.cpp
+++ b/src/Media/MediaSourceElement.cpp
@@ -395,7 +395,10 @@ MediaSourceElement::MediaSourceElement(std::string url)
 	int ret = avformat_open_input(&ctx, url.c_str(), NULL, &options_dict);
 	if (ret < 0)
 	{
-		printf("avformat_open_input failed.\n");
+		char buf[AV_ERROR_MAX_STRING_SIZE+1];
+		char *errstr = av_make_error_string(buf, AV_ERROR_MAX_STRING_SIZE, ret);
+
+		printf("avformat_open_input failed: %s (%d).\n", errstr, ret);
 	}
 
 

--- a/src/Media/MediaSourceElement.h
+++ b/src/Media/MediaSourceElement.h
@@ -30,6 +30,7 @@ extern "C"
 {
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
+#include <libavutil/error.h>
 }
 
 


### PR DESCRIPTION
This allows me to see

avformat_open_input failed: No such file or directory (-2).

and wonder why it's claiming that instead of the more opaque
message which is slightly more confusing.